### PR TITLE
step3 - multiple endpoint에서도 수행가능하도록 filter 생성

### DIFF
--- a/authorization-server/src/main/java/com/server/authorization/config/AuthorizationServerConfig.java
+++ b/authorization-server/src/main/java/com/server/authorization/config/AuthorizationServerConfig.java
@@ -7,6 +7,7 @@ import com.server.authorization.security.CustomPasswordGrantAuthenticationProvid
 import java.time.Duration;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -31,6 +32,9 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class AuthorizationServerConfig {
+
+  @Value("${oauth2.token.endpoint}")
+  private String tokenEndpoint;
 
   @Bean
   @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -100,7 +104,9 @@ public class AuthorizationServerConfig {
 
   @Bean
   public AuthorizationServerSettings authorizationServerSettings() {
-    return AuthorizationServerSettings.builder().build();
+    return AuthorizationServerSettings.builder()
+            .tokenEndpoint(tokenEndpoint)
+            .build();
   }
 
 }

--- a/authorization-server/src/main/java/com/server/authorization/filter/TokenPathRewriteFilter.java
+++ b/authorization-server/src/main/java/com/server/authorization/filter/TokenPathRewriteFilter.java
@@ -1,0 +1,44 @@
+package com.server.authorization.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TokenPathRewriteFilter extends OncePerRequestFilter {
+
+    @Value("${oauth2.token.endpoint}")
+    private String tokenEndpoint;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        List<String> tokenPaths = List.of("/oauth3/token", "/test/token");
+        // 조건에 따라 경로 변경 로직 구현
+        for (String path: tokenPaths) {
+            if (requestURI.startsWith(path)) {
+                // 실제 서버에서 /a 경로의 처리를 /b 경로로 재작성하고자 할 때 로직 구현
+                String newRequestURI = requestURI.replace(path, tokenEndpoint);
+                // 요청을 새 경로로 전달
+                request.getRequestDispatcher(newRequestURI).forward(request, response);
+                return;
+            }
+        }
+
+        // 다른 경로에 대한 요청은 변경 없이 그대로 진행
+        filterChain.doFilter(request, response);
+    }
+}

--- a/authorization-server/src/main/java/com/server/authorization/filter/TokenPathRewriteFilter.java
+++ b/authorization-server/src/main/java/com/server/authorization/filter/TokenPathRewriteFilter.java
@@ -27,18 +27,14 @@ public class TokenPathRewriteFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
 
         List<String> tokenPaths = List.of("/oauth3/token", "/test/token");
-        // 조건에 따라 경로 변경 로직 구현
         for (String path: tokenPaths) {
             if (requestURI.startsWith(path)) {
-                // 실제 서버에서 /a 경로의 처리를 /b 경로로 재작성하고자 할 때 로직 구현
                 String newRequestURI = requestURI.replace(path, tokenEndpoint);
-                // 요청을 새 경로로 전달
                 request.getRequestDispatcher(newRequestURI).forward(request, response);
                 return;
             }
         }
 
-        // 다른 경로에 대한 요청은 변경 없이 그대로 진행
         filterChain.doFilter(request, response);
     }
 }

--- a/authorization-server/src/main/resources/application.yml
+++ b/authorization-server/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+oauth2:
+  token:
+    endpoint: /oauth2/token


### PR DESCRIPTION
# 진행 한 것
- [x] JwtToken 설정
- [x] Credential 타입 토큰 생성
- [x] Custom_Password 타입 토큰 생성
- [x] CustomProvider 생성
- [x] SuccessHandler 테스트
  - 테스트 중 핸들러는 모든 response를 다 바꿔줘야 해서 어려운 점이 많아 일단 제외시켰음
- [x] multiple endpoint 테스트
  - 그러나 oauth2 표준 스펙에서는 벗어나는 것으로 보임 
    - 해결 방법
      - 리버스 프록시에서 forward
      - api gateway를 앞단에 하나 더 두고 forward
      - 서버 인스턴스를 나눠서 각각 처리하도록 생성

# 남은 것
- [ ] single connection test
- [x] headless request test
- [x] multi endpoint 테스트
- [ ] custom multi type test
- [ ] full custom access token whatever we want